### PR TITLE
Fix bug that allows 0 as a 1-based coordinate

### DIFF
--- a/src/main/java/org/jax/svann/reference/Position.java
+++ b/src/main/java/org/jax/svann/reference/Position.java
@@ -21,8 +21,8 @@ public class Position implements Comparable<Position> {
     private Position(int pos, ConfidenceInterval confidenceInterval, CoordinateSystem coordinateSystem) {
         // convert to 1-based
         this.pos = coordinateSystem.equals(CoordinateSystem.ONE_BASED) ? pos : pos + 1;
-        if (this.pos < 0) {
-            throw new IllegalArgumentException(String.format("Position `%d` cannot be negative", this.pos));
+        if (this.pos <= 0) {
+            throw new IllegalArgumentException(String.format("One-based position `%d` cannot be non-positive", this.pos));
         }
         this.confidenceInterval = Objects.requireNonNull(confidenceInterval);
     }

--- a/src/test/java/org/jax/svann/reference/PositionTest.java
+++ b/src/test/java/org/jax/svann/reference/PositionTest.java
@@ -50,9 +50,9 @@ public class PositionTest {
     @Test
     public void errorThrownWhenInvalidInput() {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Position.precise(0, CoordinateSystem.ONE_BASED));
-        assertThat(ex.getMessage(), is("Position `0` cannot be non-positive"));
+        assertThat(ex.getMessage(), is("One-based position `0` cannot be non-positive"));
 
         ex = assertThrows(IllegalArgumentException.class, () -> Position.precise(-1, CoordinateSystem.ZERO_BASED));
-        assertThat(ex.getMessage(), is("Position `0` cannot be non-positive"));
+        assertThat(ex.getMessage(), is("One-based position `0` cannot be non-positive"));
     }
 }


### PR DESCRIPTION
Fix bug that allows `0` to be used as a valid 1-based coordinate. 