### PR TITLE
refactoring Overlap class to hold the TranscriptModel 

### DIFF
--- a/src/main/java/org/jax/svann/overlap/Overlap.java
+++ b/src/main/java/org/jax/svann/overlap/Overlap.java
@@ -1,5 +1,7 @@
 package org.jax.svann.overlap;
 
+import de.charite.compbio.jannovar.reference.TranscriptModel;
+
 /**
  * An object that represents the type and degree of overlap of a structural variant and
  * a transcript or enhancer feature.
@@ -8,29 +10,31 @@ public class Overlap {
 
     private final OverlapType overlapType;
     /** This field's meaning depends on the type. For INTERGENIC, it is the distance to the 5' (left) nearest gene.
-     * For INTRONIC, it is the distance to the 5' (left) nearest exon.
+     * For INTRONIC, it is the distance to the nearest exon.
      */
-    private final int leftDistance;
+    private final int distance;
 
-    private final int rightDistance;
+
+
+    private final TranscriptModel transcriptModel;
 
     private final String description;
 
-    private boolean overlapsCds;
+    private final boolean overlapsCds;
 
 
-    public Overlap(OverlapType type, int left, int right, String desc) {
+    public Overlap(OverlapType type, TranscriptModel tmod, int d, String desc) {
         this.overlapType = type;
-        this.leftDistance = left;
-        this.rightDistance = right;
+        this.distance = d;
+        this.transcriptModel = tmod;
         this.description = desc;
         this.overlapsCds = false;
     }
 
-    public Overlap(OverlapType type,  boolean overlapsCds, String desc) {
+    public Overlap(OverlapType type,  TranscriptModel tmod, boolean overlapsCds, String desc) {
         this.overlapType = type;
-        this.leftDistance = 0;
-        this.rightDistance = 0;
+        this.transcriptModel = tmod;
+        this.distance = 0;
         this.overlapsCds = overlapsCds;
         this.description = desc;
     }
@@ -38,16 +42,22 @@ public class Overlap {
 
 
     /**
-     * @todo REVISE ME
-     * @return
+     * @return true if this overlap involves exonic sequence
      */
-    public boolean isCoding() {
+    public boolean isExonic() {
         return OverlapType.isExonic(this.overlapType);
+    }
+
+    /**
+     * @return true if this overlap involves exonic sequence
+     */
+    public boolean overlapsCds() {
+        return overlapsCds;
     }
 
     @Override
     public String toString() {
-        return String.format("VcfOverlap [%s:%s] 5': (%dbp); 3': (%dbp)",
-                overlapType, description, leftDistance, rightDistance);
+        return String.format("VcfOverlap [%s:%s] %dbp; 3'",
+                overlapType, description, distance);
     }
 }

--- a/src/main/java/org/jax/svann/priority/PrioritizedSv.java
+++ b/src/main/java/org/jax/svann/priority/PrioritizedSv.java
@@ -1,26 +1,37 @@
 package org.jax.svann.priority;
 
 import de.charite.compbio.jannovar.reference.TranscriptModel;
+import org.jax.svann.genomicreg.Enhancer;
+import org.jax.svann.hpo.HpoDiseaseSummary;
+import org.jax.svann.overlap.Overlap;
 import org.jax.svann.parse.SvEvent;
 import org.jax.svann.reference.SvType;
 import org.jax.svann.viz.Visualizable;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
+import java.util.List;
 import java.util.Set;
 
 public class PrioritizedSv implements SvPriority, Visualizable {
+    /** A structural variant that is being prioritized. */
+    private final SvEvent svEvent;
+    private final List<Overlap> overlaps;
+    private final List<Enhancer> enhancers;
+    private final List<HpoDiseaseSummary> diseases;
 
-
-
-    private PrioritizedSv(SvEvent e) {
+    private PrioritizedSv(SvEvent e, List<Overlap> overlaps, List<Enhancer> enhancers, List<HpoDiseaseSummary> diseases) {
+        this.svEvent = e;
+        this.overlaps = overlaps;
+        this.enhancers = enhancers;
+        this.diseases = diseases;
 
     }
 
 
 
-    public static PrioritizedSv fromSvEvent(SvEvent sve) {
+    public static PrioritizedSv fromSvEvent(SvEvent sve, List<Overlap> overlaps, List<Enhancer> enhancers, List<HpoDiseaseSummary> diseases) {
 
-        return new PrioritizedSv(sve);
+        return new PrioritizedSv(sve, overlaps, enhancers, diseases);
     }
 
 
@@ -40,13 +51,19 @@ public class PrioritizedSv implements SvPriority, Visualizable {
     }
 
     @Override
-    public SvType getSvType() {
+    public Set<Enhancer> getAffectedEnhancers() {
         return null;
     }
 
     @Override
+    public SvImpact getSvImpact() {
+        return null;
+    }
+
+    /** An SvEvent is phenotypically relevant if it is assigned to one or more diseases. */
+    @Override
     public boolean hasPhenotypicRelevance() {
-        return false;
+        return this.diseases.size() > 0;
     }
 
     @Override

--- a/src/main/java/org/jax/svann/priority/SvPriority.java
+++ b/src/main/java/org/jax/svann/priority/SvPriority.java
@@ -1,6 +1,7 @@
 package org.jax.svann.priority;
 
 import de.charite.compbio.jannovar.reference.TranscriptModel;
+import org.jax.svann.genomicreg.Enhancer;
 import org.jax.svann.reference.SvType;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -15,7 +16,9 @@ public interface SvPriority {
 
     Set<TermId> getAffectedGeneIds();
 
-    SvType getSvType();
+    Set<Enhancer> getAffectedEnhancers();
+
+    SvImpact getSvImpact();
 
     /** If true, the SV overlaps with a transcript or genomic regulatory element that is annotated
      * to an HPO term representing the phenotypic observations in the proband.


### PR DESCRIPTION
Each ``Overlap`` references one overlapping TranscriptModel, but we previously did not keep track of the transcript model in the ``Overlap`` object. We need the Gene ID, and symbol for downstream stuff, and so I have added this back. I am not 100% sure about whether/how to store distance about how far away an SV is from the transcript -- but I think we can remove this information from the Overlap object since it can easily be recalculated and will not play a role in prioritization (only for display of say upstream SVs).