### PR TITLE
Convenience methods, checks

### DIFF
--- a/src/main/java/org/jax/svann/parse/SimpleSequenceRearrangement.java
+++ b/src/main/java/org/jax/svann/parse/SimpleSequenceRearrangement.java
@@ -16,17 +16,21 @@ class SimpleSequenceRearrangement implements SequenceRearrangement {
 
     private final List<Adjacency> adjacencies;
 
+    private SimpleSequenceRearrangement(SvType type, List<Adjacency> adjacencies) {
+        if (adjacencies.isEmpty()) {
+            throw new IllegalArgumentException("Adjacency list cannot be empty");
+        }
+        this.type = type;
+        this.adjacencies = adjacencies;
+
+    }
+
     public static SimpleSequenceRearrangement of(SvType type, Adjacency... adjacencies) {
         return new SimpleSequenceRearrangement(type, Arrays.asList(adjacencies));
     }
 
     public static SimpleSequenceRearrangement of(SvType type, List<Adjacency> adjacencies) {
         return new SimpleSequenceRearrangement(type, adjacencies);
-    }
-
-    private SimpleSequenceRearrangement(SvType type, List<Adjacency> adjacencies) {
-        this.type = type;
-        this.adjacencies = adjacencies;
     }
 
     @Override

--- a/src/main/java/org/jax/svann/reference/SequenceRearrangement.java
+++ b/src/main/java/org/jax/svann/reference/SequenceRearrangement.java
@@ -2,6 +2,15 @@ package org.jax.svann.reference;
 
 import java.util.List;
 
+/**
+ * General representation of structural as well as small variants.
+ * <p>
+ * Implementors must ensure that the following invariants are met:
+ * <ul>
+ *     <li>at least one adjacency is present</li>
+ *     <li>adjacencies are sorted in representative order for the variant</li>
+ * </ul>
+ */
 public interface SequenceRearrangement {
 
     /**
@@ -23,11 +32,36 @@ public interface SequenceRearrangement {
     SequenceRearrangement withStrand(Strand strand);
 
     /**
-     * @return strand of the first adjacency
+     * @return strand of the leftmost position of the rearrangement
      */
-    default Strand getStrand() {
-        return getAdjacencies().isEmpty()
-                ? Strand.FWD
-                : getAdjacencies().get(0).getStrand();
+    default Strand getLeftmostStrand() {
+        return getAdjacencies().get(0).getLeft().getStrand();
+    }
+
+    /**
+     * Get leftmost position of the rearrangement. The position is on the strand that you get by {@link #getLeftmostStrand()}.
+     *
+     * @return coordinate of the leftmost position of the rearrangement
+     */
+    default int getLeftmostPosition() {
+        return getAdjacencies().get(0).getLeft().getBegin();
+    }
+
+    /**
+     * @return strand of the rightmost position of the rearrangement
+     */
+    default Strand getRightmostStrand() {
+        int n = getAdjacencies().size();
+        return getAdjacencies().get(n - 1).getRight().getStrand();
+    }
+
+    /**
+     * Get rightmost position of the rearrangement. The position is on the strand that you get by {@link #getRightmostStrand()}.
+     *
+     * @return coordinate of the rightmost position of the rearrangement
+     */
+    default int getRightmostPosition() {
+        int n = getAdjacencies().size();
+        return getAdjacencies().get(n - 1).getRight().getBegin();
     }
 }

--- a/src/test/java/org/jax/svann/parse/BreakendAssemblerTest.java
+++ b/src/test/java/org/jax/svann/parse/BreakendAssemblerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -92,7 +91,8 @@ public class BreakendAssemblerTest extends TestBase {
 
         SequenceRearrangement rearrangement = rearrangementOpt.get();
         assertThat(rearrangement.getType(), is(SvType.TRANSLOCATION));
-        assertThat(rearrangement.getStrand(), is(Strand.FWD)); // W is on FWD strand
+        assertThat(rearrangement.getLeftmostStrand(), is(Strand.FWD)); // W is on FWD strand
+        assertThat(rearrangement.getRightmostStrand(), is(Strand.REV)); // Y is on REV strand
 
         List<Adjacency> adjacencies = rearrangement.getAdjacencies();
         assertThat(adjacencies, hasSize(1));
@@ -130,7 +130,8 @@ public class BreakendAssemblerTest extends TestBase {
 
         SequenceRearrangement rearrangement = rearrangementOpt.get();
         assertThat(rearrangement.getType(), is(SvType.TRANSLOCATION));
-        assertThat(rearrangement.getStrand(), is(Strand.FWD)); // U is on FWD strand
+        assertThat(rearrangement.getLeftmostStrand(), is(Strand.FWD)); // U is on FWD strand
+        assertThat(rearrangement.getRightmostStrand(), is(Strand.FWD)); // V is on FWD strand
 
         List<Adjacency> adjacencies = rearrangement.getAdjacencies();
         assertThat(adjacencies, hasSize(1));
@@ -168,7 +169,8 @@ public class BreakendAssemblerTest extends TestBase {
 
         SequenceRearrangement rearrangement = rearrangementOpt.get();
         assertThat(rearrangement.getType(), is(SvType.TRANSLOCATION));
-        assertThat(rearrangement.getStrand(), is(Strand.REV)); // X is on REV strand
+        assertThat(rearrangement.getLeftmostStrand(), is(Strand.REV)); // X is on REV strand
+        assertThat(rearrangement.getRightmostStrand(), is(Strand.FWD)); // Z is on FWD strand
 
         List<Adjacency> adjacencies = rearrangement.getAdjacencies();
         assertThat(adjacencies, hasSize(1));

--- a/src/test/java/org/jax/svann/parse/SimpleSequenceRearrangementTest.java
+++ b/src/test/java/org/jax/svann/parse/SimpleSequenceRearrangementTest.java
@@ -50,7 +50,7 @@ public class SimpleSequenceRearrangementTest extends ToyCoordinateTestBase {
         rearrangement = instance.withStrand(Strand.REV);
 
         // assert
-        assertThat(rearrangement.getStrand(), is(Strand.REV));
+        assertThat(rearrangement.getLeftmostStrand(), is(Strand.REV));
         assertThat(rearrangement.getType(), is(SvType.INVERSION));
 
         List<Adjacency> adjacencies = rearrangement.getAdjacencies();
@@ -79,5 +79,25 @@ public class SimpleSequenceRearrangementTest extends ToyCoordinateTestBase {
         assertThat(betaRight.getBegin(), is(21));
         assertThat(betaRight.getStrand(), is(Strand.REV));
         assertThat(betaRight.getId(), is("alphaLeft"));
+    }
+
+    @Test
+    public void getLeftmostStrand() {
+        assertThat(instance.getLeftmostStrand(), is(Strand.FWD));
+    }
+
+    @Test
+    public void getLeftmostPosition() {
+        assertThat(instance.getLeftmostPosition(), is(10));
+    }
+
+    @Test
+    public void getRightmostStrand() {
+        assertThat(instance.getRightmostStrand(), is(Strand.FWD));
+    }
+
+    @Test
+    public void getRightmostPosition() {
+        assertThat(instance.getRightmostPosition(), is(20));
     }
 }


### PR DESCRIPTION
Add convenience methods, check that adjacency list is not empty when creating a structural rearrangement.