### PR TITLE
Fix erroneous OverlapType (500KB is actually 500B)

### DIFF
--- a/src/main/java/org/jax/svann/overlap/OverlapType.java
+++ b/src/main/java/org/jax/svann/overlap/OverlapType.java
@@ -22,9 +22,9 @@ public enum OverlapType {
      */
     DOWNSTREAM_GENE_VARIANT_5KB("5kb downstream gene variant"),
     /**
-     * 500KB_downstream_variant (SO:0001634)
+     * 500B_downstream_variant (SO:0001634)
      */
-    DOWNSTREAM_GENE_VARIANT_500KB("500kb downstream gene variant"),
+    DOWNSTREAM_GENE_VARIANT_500B("500b downstream gene variant"),
     /**
      * upstream_gene_variant (SO:0001631)
      */
@@ -48,7 +48,7 @@ public enum OverlapType {
     UNKNOWN("unknown");
 
     private final static Set<OverlapType> intergenicTypes = Set.of(DOWNSTREAM_GENE_VARIANT, DOWNSTREAM_GENE_VARIANT_2KB, DOWNSTREAM_GENE_VARIANT_5KB,
-            DOWNSTREAM_GENE_VARIANT_500KB, UPSTREAM_GENE_VARIANT, UPSTREAM_GENE_VARIANT_2KB, UPSTREAM_GENE_VARIANT_5KB, UPSTREAM_GENE_VARIANT_500KB);
+            DOWNSTREAM_GENE_VARIANT_500B, UPSTREAM_GENE_VARIANT, UPSTREAM_GENE_VARIANT_2KB, UPSTREAM_GENE_VARIANT_5KB, UPSTREAM_GENE_VARIANT_500KB);
     private final static Set<OverlapType> exonicTypes = Set.of(SINGLE_EXON_IN_TRANSCRIPT, MULTIPLE_EXON_IN_TRANSCRIPT, TRANSCRIPT_CONTAINED_IN_SV);
     private final static Set<OverlapType> intronicTypes = Set.of(INTRONIC);
 

--- a/src/main/java/org/jax/svann/overlap/Overlapper.java
+++ b/src/main/java/org/jax/svann/overlap/Overlapper.java
@@ -281,12 +281,12 @@ public class Overlapper {
         if (tmodelRight != null) {
             int rightDistance = tmodelRight.getTXRegion().withStrand(Strand.FWD).getBeginPos() - end.getPos();
             description = String.format("%s[%s]", tmodelRight.getGeneSymbol(), tmodelRight.getGeneID());
-            if (rightDistance <= 2_000) {
+            if (rightDistance <= 500) {
+                overlaps.add(new Overlap(OverlapType.DOWNSTREAM_GENE_VARIANT_500B, tmodelRight, rightDistance, description));
+            } else if (rightDistance <= 2_000) {
                 overlaps.add(new Overlap(OverlapType.DOWNSTREAM_GENE_VARIANT_2KB, tmodelRight, rightDistance, description));
             } else if (rightDistance <= 5_000) {
                 overlaps.add(new Overlap(OverlapType.DOWNSTREAM_GENE_VARIANT_5KB, tmodelRight, rightDistance, description));
-            } else if (rightDistance <= 500_000) {
-                overlaps.add(new Overlap(OverlapType.DOWNSTREAM_GENE_VARIANT_500KB, tmodelRight, rightDistance, description));
             } else {
                 overlaps.add(new Overlap(OverlapType.DOWNSTREAM_GENE_VARIANT, tmodelRight, rightDistance, description));
             }

--- a/src/test/java/org/jax/svann/overlap/OverlapperTest.java
+++ b/src/test/java/org/jax/svann/overlap/OverlapperTest.java
@@ -3,8 +3,6 @@ package org.jax.svann.overlap;
 import org.jax.svann.TestBase;
 import org.jax.svann.parse.TestVariants;
 import org.jax.svann.reference.SequenceRearrangement;
-import org.jax.svann.reference.genome.Contig;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +12,6 @@ import java.util.stream.Collectors;
 
 import static org.jax.svann.overlap.OverlapType.*;
 import static org.jax.svann.parse.TestVariants.*;
-import static org.jax.svann.reference.SvType.INSERTION;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -188,7 +185,7 @@ public class OverlapperTest extends TestBase {
         assertEquals(1, overlaps.size());
         Overlap overlap = overlaps.get(0);
         assertEquals("SURF1", overlap.getGeneSymbol());
-        assertEquals(DOWNSTREAM_GENE_VARIANT_500KB, overlap.getOverlapType());
+        assertEquals(DOWNSTREAM_GENE_VARIANT, overlap.getOverlapType());
         assertFalse(overlap.overlapsCds());
     }
 
@@ -196,17 +193,16 @@ public class OverlapperTest extends TestBase {
     /**
      * Deletion upstream intergenic.
      * <p>
-     * SURF1:NM_017503.5 upstream, 10kb deletion
-     * chr9:133_380_001-133_381_000
+     * BRCA2:NM_0000059 upstream, 10kb deletion
+     * chr13:32_280_001-32_290_000
      */
-
     @Test
     public void testDeletionUpstreamIntergenic() {
         SequenceRearrangement surf1Upstream = deletionUpstreamIntergenic();
         List<Overlap> overlaps = overlapper.getOverlapList(surf1Upstream);
         assertEquals(1, overlaps.size());
         Overlap overlap = overlaps.get(0);
-        assertEquals("SURF2", overlap.getGeneSymbol());
+        assertEquals("BRCA2", overlap.getGeneSymbol());
         assertEquals(UPSTREAM_GENE_VARIANT_500KB, overlap.getOverlapType());
         assertFalse(overlap.overlapsCds());
     }

--- a/src/test/java/org/jax/svann/parse/TestVariants.java
+++ b/src/test/java/org/jax/svann/parse/TestVariants.java
@@ -145,12 +145,12 @@ public class TestVariants extends TestBase {
      * chr13:32_280_001-32_290_000
      */
     public static SequenceRearrangement deletionUpstreamIntergenic() {
-        Contig chr9 = GENOME_ASSEMBLY.getContigByName("9").get();
+        Contig chr13 = GENOME_ASSEMBLY.getContigByName("13").get();
         SimpleBreakend left = SimpleBreakend.of(
-                ChromosomalPosition.of(chr9, Position.precise(32_280_001), Strand.FWD),
+                ChromosomalPosition.of(chr13, Position.precise(32_280_001), Strand.FWD),
                 "del_upstream_intergenic_l", "T");
         SimpleBreakend right = SimpleBreakend.of(
-                ChromosomalPosition.of(chr9, Position.precise(32_290_000), Strand.FWD),
+                ChromosomalPosition.of(chr13, Position.precise(32_290_000), Strand.FWD),
                 "del_upstream_intergenic_r", "G");
 
         return SimpleSequenceRearrangement.of(SvType.DELETION, SimpleAdjacency.empty(left, right));


### PR DESCRIPTION
There is a typo in `OverlapType`, where `500KB_downstream_variant` is actually `500B_...` (SO term [here](http://www.sequenceontology.org/browser/current_release/term/SO:0001634))