### PR TITLE
SVG for non-coding

### DIFF
--- a/svanna-core/src/main/java/org/jax/svanna/core/viz/svg/SvSvgGenerator.java
+++ b/svanna-core/src/main/java/org/jax/svanna/core/viz/svg/SvSvgGenerator.java
@@ -319,6 +319,22 @@ public abstract class SvSvgGenerator {
     }
 
 
+
+    protected void writeNoncodingTranscript(Transcript tmod, int ypos, Writer writer) throws IOException {
+        Transcript transcript = tmod.withStrand(Strand.POSITIVE);
+        List<GenomicRegion> exons = transcript.exons();
+        double minX = Double.MAX_VALUE;
+        // All exons are untranslated
+        for (GenomicRegion exon : exons) {
+            double exonStart = translateGenomicToSvg(exon.start());
+            double exonEnd = translateGenomicToSvg(exon.end());
+            writeUtrExon(exonStart, exonEnd, ypos, writer);
+        }
+        writeIntrons(exons, ypos, writer);
+        writeTranscriptName(transcript, minX, ypos, writer);
+    }
+
+
     /**
      * This method writes one Jannovar transcript as a cartoon where the UTRs are shown in one color and the
      * the coding exons are shown in another color. TODO -- decide what to do with non-coding genes
@@ -330,8 +346,11 @@ public abstract class SvSvgGenerator {
      */
     protected void writeTranscript(Transcript tmod, int ypos, Writer writer) throws IOException {
         Transcript transcript = tmod.withStrand(Strand.POSITIVE);
+        if (! transcript.isCoding()) {
+            writeNoncodingTranscript(tmod, ypos, writer);
+            return;
+        }
         GenomicRegion cds = transcript.cdsRegion();
-
         double cdsStart = translateGenomicToSvg(cds.start());
         double cdsEnd = translateGenomicToSvg(cds.end());
         List<GenomicRegion> exons = transcript.exons();


### PR DESCRIPTION
Addresses https://github.com/TheJacksonLaboratory/svann/issues/119
I am still getting other errors
Error parsing LineIteratorImpl(SynchronousLineReader) just after record at: CM000663.2:2681023-2681023, for input source: 231501_hifi_2smrtcell_hg38_pbmm2_sniffles.vcf
For input string: "PASS" (I think this is the issue you were describing).
I have not testing this but I am pretty sure it should work and so we could merge. I will plan on revising all of the SVG code in the next several days.