### PR TITLE
Prioritize `TRA` and `BND`s using the same rules

### DIFF
--- a/svanna-core/src/main/java/org/jax/svanna/core/prioritizer/PrototypeSvPrioritizer.java
+++ b/svanna-core/src/main/java/org/jax/svanna/core/prioritizer/PrototypeSvPrioritizer.java
@@ -141,6 +141,7 @@ public class PrototypeSvPrioritizer implements SvPrioritizer {
             case INV:
                 return prioritizeInversion(variant);
             case TRA:
+            case BND:
                 return prioritizeTranslocation(variant);
             case DUP:
                 return prioritizeDuplication(variant);


### PR DESCRIPTION
@pnrobinson a branch for `BND` was missing in the _switch_ statement. So translocation prioritization should work again in `PrototypeSvPrioritizer`.