### PR TITLE
Report unfiltered variants in HTML output.

### DIFF
--- a/svanna-cli/src/main/java/org/monarchinitiative/svanna/cli/writer/html/HtmlResultWriter.java
+++ b/svanna-cli/src/main/java/org/monarchinitiative/svanna/cli/writer/html/HtmlResultWriter.java
@@ -70,8 +70,7 @@ public class HtmlResultWriter implements ResultWriter {
         // Limit performing of the expensive DB lookups to several dozens of variants that will be reported
         // in the report, and not to the entire variant corpus
         List<String> visualizations = variantLandscapes.stream()
-                .filter(s -> s.variant().numberOfAltReads() >= analysisParameters.minAltReadSupport()
-                        && s.variant().passedFilters()
+                .filter(s -> s.variant().passedFilters()
                         && !Double.isNaN(s.variant().svPriority().getPriority()))
                 .filter(v -> !(v.variant() instanceof GenomicBreakendVariant) || !doNotReportBreakends)
                 .limit(outputOptions.nVariantsToReport())

--- a/svanna-cli/src/main/java/org/monarchinitiative/svanna/cli/writer/vcf/VcfResultWriter.java
+++ b/svanna-cli/src/main/java/org/monarchinitiative/svanna/cli/writer/vcf/VcfResultWriter.java
@@ -77,15 +77,15 @@ public class VcfResultWriter implements ResultWriter {
             VariantContext vc = sv.variantContext();
             if (vc == null) {
                 GenomicVariant gv = sv.genomicVariant();
-                LogUtils.logDebug(LOGGER, "Cannot write VCF line for variant '{}' because variant context is missing. {}:{}{}>{}",
+                LOGGER.debug("Cannot write VCF line for variant '{}' because variant context is missing. {}:{}{}>{}",
                         gv.id(), gv.contig().name(), gv.startOnStrandWithCoordinateSystem(gv.strand(), CoordinateSystem.oneBased()), gv.ref(), gv.alt());
                 return Optional.empty();
             }
 
-            VariantContextBuilder builder = new VariantContextBuilder(vc);
             if (svPriority == null || Double.isNaN(svPriority.getPriority()))
-                return Optional.of(builder.make());
+                return Optional.of(vc);
 
+            VariantContextBuilder builder = new VariantContextBuilder(vc);
             return Optional.of(builder.attribute(SVANNA_PSV_FIELD_NAME, svPriority.getPriority())
                     .make());
         };


### PR DESCRIPTION
Fix bug where the variants with no coverage information have no chance of making it into the HTML report.